### PR TITLE
[multi-DB] Part 5: Golang API changes and replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ export GOPATH=/tmp/go
 endif
 
 INSTALL := /usr/bin/install
+DBDIR := /var/run/redis/sonic-db/
 
 all: sonic-telemetry
 
@@ -11,8 +12,12 @@ sonic-telemetry:
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 
 check:
+	mkdir -p ${DBDIR}
+	rsync -a ./testdata/database_config.json  ${DBDIR}
 	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/gnmi_server/...
 	/usr/local/go/bin/go test -v ${GOPATH}/src/github.com/Azure/sonic-telemetry/gnmi_server
+	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/dialout/dialout_client/...
+	/usr/local/go/bin/go test -v ${GOPATH}/src/github.com/Azure/sonic-telemetry/dialout/dialout_client
 
 install:
 	$(INSTALL) -D ${GOPATH}/bin/telemetry $(DESTDIR)/usr/sbin/telemetry

--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,17 @@ DBDIR := /var/run/redis/sonic-db/
 all: sonic-telemetry
 
 sonic-telemetry:
-# copy sonic-telemetry source code into ${GOPATH}/src directory for building, otherwise it is not using committed codes
+	# copy sonic-telemetry source code into ${GOPATH}/src directory for building, otherwise it is not using committed codes
 	mkdir -p ${GOPATH}/src/github.com/Azure
-	rsync -a ../sonic-telemetry ${GOPATH}/src/github.com/Azure/
+	cp -r ../sonic-telemetry ${GOPATH}/src/github.com/Azure/
 	cd ${GOPATH}/src/github.com/Azure/sonic-telemetry
-# go get won't overwrite exsisting ${GOPATH}/src/sonic-telemetry directory and download other package
+	# go get won't overwrite exsisting ${GOPATH}/src/sonic-telemetry directory and download other package
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/telemetry
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 
 check:
 	sudo mkdir -p ${DBDIR}
-	sudo rsync -a ./testdata/database_config.json  ${DBDIR}
+	sudo cp ./testdata/database_config.json ${DBDIR}
 	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/gnmi_server/...
 	/usr/local/go/bin/go test -v ${GOPATH}/src/github.com/Azure/sonic-telemetry/gnmi_server
 	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/dialout/dialout_client/...

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ DBDIR := /var/run/redis/sonic-db/
 all: sonic-telemetry
 
 sonic-telemetry:
+# copy sonic-telemetry source code into ${GOPATH}/src directory for building, otherwise it is not using committed codes
+	mkdir -p ${GOPATH}/src/github.com/Azure
+	rsync -a ../sonic-telemetry ${GOPATH}/src/github.com/Azure/
+	cd ${GOPATH}/src/github.com/Azure/sonic-telemetry
+# go get won't overwrite exsisting ${GOPATH}/src/sonic-telemetry directory and download other package
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/telemetry
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 

--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,15 @@ DBDIR := /var/run/redis/sonic-db/
 all: sonic-telemetry
 
 sonic-telemetry:
-	# copy sonic-telemetry source code into ${GOPATH}/src directory for building, otherwise it is not using committed codes
-	mkdir -p ${GOPATH}/src/github.com/Azure
-	cp -r ../sonic-telemetry ${GOPATH}/src/github.com/Azure/
-	# go get won't overwrite existing ${GOPATH}/src/sonic-telemetry directory and download other package
-	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/telemetry
-	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
+	/usr/local/go/bin/go mod init github.com/Azure/sonic-telemetry
+	/usr/local/go/bin/go install github.com/Azure/sonic-telemetry/telemetry
+	/usr/local/go/bin/go install github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 
 check:
 	sudo mkdir -p ${DBDIR}
 	sudo cp ./testdata/database_config.json ${DBDIR}
-	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/gnmi_server/...
-	/usr/local/go/bin/go test -v ${GOPATH}/src/github.com/Azure/sonic-telemetry/gnmi_server
-	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/dialout/dialout_client/...
-	/usr/local/go/bin/go test -v ${GOPATH}/src/github.com/Azure/sonic-telemetry/dialout/dialout_client
+	/usr/local/go/bin/go test -v github.com/Azure/sonic-telemetry/gnmi_server
+	/usr/local/go/bin/go test -v github.com/Azure/sonic-telemetry/dialout/dialout_client
 
 install:
 	$(INSTALL) -D ${GOPATH}/bin/telemetry $(DESTDIR)/usr/sbin/telemetry
@@ -33,4 +28,6 @@ deinstall:
 
 clean:
 	rm -fr ${GOPATH}
+	rm -rf go.mod
+	rm -rf go.sum
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ sonic-telemetry:
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 
 check:
-	mkdir -p ${DBDIR}
-	rsync -a ./testdata/database_config.json  ${DBDIR}
+	sudo mkdir -p ${DBDIR}
+	sudo rsync -a ./testdata/database_config.json  ${DBDIR}
 	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/gnmi_server/...
 	/usr/local/go/bin/go test -v ${GOPATH}/src/github.com/Azure/sonic-telemetry/gnmi_server
 	/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/dialout/dialout_client/...

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ sonic-telemetry:
 	# copy sonic-telemetry source code into ${GOPATH}/src directory for building, otherwise it is not using committed codes
 	mkdir -p ${GOPATH}/src/github.com/Azure
 	cp -r ../sonic-telemetry ${GOPATH}/src/github.com/Azure/
-	cd ${GOPATH}/src/github.com/Azure/sonic-telemetry
-	# go get won't overwrite exsisting ${GOPATH}/src/sonic-telemetry directory and download other package
+	# go get won't overwrite existing ${GOPATH}/src/sonic-telemetry directory and download other package
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/telemetry
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 

--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -642,7 +642,7 @@ func processTelemetryClientConfig(ctx context.Context, redisDb *redis.Client, ke
 // read configDB data for telemetry client and start publishing service for client subscription
 func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 	clientCfg = ccfg
-	dbn := spb.Target_value["CONFIG_DB"]
+	dbn := sdcfg.GetDbId("CONFIG_DB")
 
 	var redisDb *redis.Client
 	if sdc.UseRedisLocalTcpPort == false {
@@ -650,7 +650,7 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 			Network:     "unix",
 			Addr:        sdcfg.GetDbSock("CONFIG_DB"),
 			Password:    "", // no password set
-			DB:          int(dbn),
+			DB:          dbn,
 			DialTimeout: 0,
 		})
 	} else {
@@ -658,7 +658,7 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 			Network:     "tcp",
 			Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB"),
 			Password:    "", // no password set
-			DB:          int(dbn),
+			DB:          dbn,
 			DialTimeout: 0,
 		})
 	}

--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	spb "github.com/Azure/sonic-telemetry/proto"
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
+	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	"github.com/go-redis/redis"
 	log "github.com/golang/glog"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -647,7 +648,7 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 	if sdc.UseRedisLocalTcpPort == false {
 		redisDb = redis.NewClient(&redis.Options{
 			Network:     "unix",
-			Addr:        sdc.Default_REDIS_UNIXSOCKET,
+			Addr:        sdcfg.GetDbSock("CONFIG_DB"),
 			Password:    "", // no password set
 			DB:          int(dbn),
 			DialTimeout: 0,
@@ -655,7 +656,7 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 	} else {
 		redisDb = redis.NewClient(&redis.Options{
 			Network:     "tcp",
-			Addr:        sdc.Default_REDIS_LOCAL_TCP_PORT,
+			Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB"),
 			Password:    "", // no password set
 			DB:          int(dbn),
 			DialTimeout: 0,

--- a/dialout/dialout_client/dialout_client_test.go
+++ b/dialout/dialout_client/dialout_client_test.go
@@ -31,6 +31,7 @@ import (
 	sds "github.com/Azure/sonic-telemetry/dialout/dialout_server"
 	spb "github.com/Azure/sonic-telemetry/proto"
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
+	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	gclient "github.com/openconfig/gnmi/client/gnmi"
 )
 
@@ -98,7 +99,7 @@ func getRedisClient(t *testing.T) *redis.Client {
 	dbn := spb.Target_value["COUNTERS_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
-		Addr:        "localhost:6379",
+		Addr:        sdcfg.GetDbTcpAddr("COUNTERS_DB"),
 		Password:    "", // no password set
 		DB:          int(dbn),
 		DialTimeout: 0,
@@ -128,7 +129,7 @@ func getConfigDbClient(t *testing.T) *redis.Client {
 	dbn := spb.Target_value["CONFIG_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
-		Addr:        "localhost:6379",
+		Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB"),
 		Password:    "", // no password set
 		DB:          int(dbn),
 		DialTimeout: 0,
@@ -157,7 +158,7 @@ func loadConfigDB(t *testing.T, rclient *redis.Client, mpi map[string]interface{
 func prepareConfigDb(t *testing.T) {
 	rclient := getConfigDbClient(t)
 	defer rclient.Close()
-	rclient.FlushDb()
+	rclient.FlushDB()
 
 	fileName := "../../testdata/COUNTERS_PORT_ALIAS_MAP.txt"
 	countersPortAliasMapByte, err := ioutil.ReadFile(fileName)
@@ -179,7 +180,7 @@ func prepareConfigDb(t *testing.T) {
 func prepareDb(t *testing.T) {
 	rclient := getRedisClient(t)
 	defer rclient.Close()
-	rclient.FlushDb()
+	rclient.FlushDB()
 	//Enable keysapce notification
 	os.Setenv("PATH", "$PATH:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/Cellar/redis/4.0.8/bin")
 	cmd := exec.Command("redis-cli", "config", "set", "notify-keyspace-events", "KEA")

--- a/dialout/dialout_client/dialout_client_test.go
+++ b/dialout/dialout_client/dialout_client_test.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	sds "github.com/Azure/sonic-telemetry/dialout/dialout_server"
-	spb "github.com/Azure/sonic-telemetry/proto"
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
 	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	gclient "github.com/openconfig/gnmi/client/gnmi"
@@ -96,12 +95,11 @@ func runServer(t *testing.T, s *sds.Server) {
 }
 
 func getRedisClient(t *testing.T) *redis.Client {
-	dbn := spb.Target_value["COUNTERS_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
 		Addr:        sdcfg.GetDbTcpAddr("COUNTERS_DB"),
 		Password:    "", // no password set
-		DB:          int(dbn),
+		DB:          sdcfg.GetDbId("COUNTERS_DB"),
 		DialTimeout: 0,
 	})
 	_, err := rclient.Ping().Result()
@@ -126,12 +124,11 @@ func exe_cmd(t *testing.T, cmd string) {
 }
 
 func getConfigDbClient(t *testing.T) *redis.Client {
-	dbn := spb.Target_value["CONFIG_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
 		Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB"),
 		Password:    "", // no password set
-		DB:          int(dbn),
+		DB:          sdcfg.GetDbId("CONFIG_DB"),
 		DialTimeout: 0,
 	})
 	_, err := rclient.Ping().Result()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 	// Register supported client types.
-	spb "github.com/Azure/sonic-telemetry/proto"
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
 	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	gclient "github.com/jipanyang/gnmi/client/gnmi"
@@ -156,12 +155,11 @@ func runServer(t *testing.T, s *Server) {
 }
 
 func getRedisClient(t *testing.T) *redis.Client {
-	dbn := spb.Target_value["COUNTERS_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
 		Addr:        sdcfg.GetDbTcpAddr("COUNTERS_DB"),
 		Password:    "", // no password set
-		DB:          int(dbn),
+		DB:          sdcfg.GetDbId("COUNTERS_DB"),
 		DialTimeout: 0,
 	})
 	_, err := rclient.Ping().Result()
@@ -172,12 +170,11 @@ func getRedisClient(t *testing.T) *redis.Client {
 }
 
 func getConfigDbClient(t *testing.T) *redis.Client {
-	dbn := spb.Target_value["CONFIG_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
 		Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB"),
 		Password:    "", // no password set
-		DB:          int(dbn),
+		DB:          sdcfg.GetDbId("CONFIG_DB"),
 		DialTimeout: 0,
 	})
 	_, err := rclient.Ping().Result()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -28,6 +28,7 @@ import (
 	// Register supported client types.
 	spb "github.com/Azure/sonic-telemetry/proto"
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
+	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	gclient "github.com/jipanyang/gnmi/client/gnmi"
 )
 
@@ -158,7 +159,7 @@ func getRedisClient(t *testing.T) *redis.Client {
 	dbn := spb.Target_value["COUNTERS_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
-		Addr:        "localhost:6379",
+		Addr:        sdcfg.GetDbTcpAddr("COUNTERS_DB"),
 		Password:    "", // no password set
 		DB:          int(dbn),
 		DialTimeout: 0,
@@ -174,7 +175,7 @@ func getConfigDbClient(t *testing.T) *redis.Client {
 	dbn := spb.Target_value["CONFIG_DB"]
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
-		Addr:        "localhost:6379",
+		Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB"),
 		Password:    "", // no password set
 		DB:          int(dbn),
 		DialTimeout: 0,
@@ -203,7 +204,7 @@ func loadConfigDB(t *testing.T, rclient *redis.Client, mpi map[string]interface{
 func prepareConfigDb(t *testing.T) {
 	rclient := getConfigDbClient(t)
 	defer rclient.Close()
-	rclient.FlushDb()
+	rclient.FlushDB()
 
 	fileName := "../testdata/COUNTERS_PORT_ALIAS_MAP.txt"
 	countersPortAliasMapByte, err := ioutil.ReadFile(fileName)
@@ -225,7 +226,7 @@ func prepareConfigDb(t *testing.T) {
 func prepareDb(t *testing.T) {
 	rclient := getRedisClient(t)
 	defer rclient.Close()
-	rclient.FlushDb()
+	rclient.FlushDB()
 	//Enable keysapce notification
 	os.Setenv("PATH", "/usr/bin:/sbin:/bin:/usr/local/bin")
 	cmd := exec.Command("redis-cli", "config", "set", "notify-keyspace-events", "KEA")

--- a/proto/sonic.pb.go
+++ b/proto/sonic.pb.go
@@ -7,6 +7,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/openconfig/gnmi/proto/gnmi"
+import sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -16,40 +17,10 @@ var _ = math.Inf
 // target - the name of the target for which the path is a member. Only set in prefix for a path.
 type Target int32
 
-const (
-	Target_APPL_DB     Target = 0
-	Target_ASIC_DB     Target = 1
-	Target_COUNTERS_DB Target = 2
-	Target_LOGLEVEL_DB Target = 3
-	Target_CONFIG_DB   Target = 4
-	// PFC_WD_DB shares the the same db number with FLEX_COUNTER_DB
-	Target_PFC_WD_DB       Target = 5
-	Target_FLEX_COUNTER_DB Target = 5
-	Target_STATE_DB        Target = 6
-	// For none-DB data
-	Target_OTHERS Target = 100
-)
-
 var Target_name = map[int32]string{
-	0: "APPL_DB",
-	1: "ASIC_DB",
-	2: "COUNTERS_DB",
-	3: "LOGLEVEL_DB",
-	4: "CONFIG_DB",
-	5: "PFC_WD_DB",
-	// Duplicate value: 5: "FLEX_COUNTER_DB",
-	6:   "STATE_DB",
 	100: "OTHERS",
 }
 var Target_value = map[string]int32{
-	"APPL_DB":         0,
-	"ASIC_DB":         1,
-	"COUNTERS_DB":     2,
-	"LOGLEVEL_DB":     3,
-	"CONFIG_DB":       4,
-	"PFC_WD_DB":       5,
-	"FLEX_COUNTER_DB": 5,
-	"STATE_DB":        6,
 	"OTHERS":          100,
 }
 
@@ -58,7 +29,17 @@ func (x Target) String() string {
 }
 func (Target) EnumDescriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
 
+func setTarget() {
+    db_list := sdcfg.GetDbList()
+    for dbname, v := range db_list {
+        id := v.(map[string]interface{})["id"].(float64)
+        Target_value[dbname] = int32(id)
+        Target_name[int32(id)] = dbname
+    }
+}
+
 func init() {
+	setTarget()
 	proto.RegisterEnum("gnmi.sonic.Target", Target_name, Target_value)
 }
 

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/golang/glog"
 
 	spb "github.com/Azure/sonic-telemetry/proto"
+	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	"github.com/go-redis/redis"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/workiva/go-datastructures/queue"
@@ -24,8 +25,6 @@ const (
 	// indentString represents the default indentation string used for
 	// JSON. Two spaces are used here.
 	indentString                 string = "  "
-	Default_REDIS_UNIXSOCKET     string = "/var/run/redis/redis.sock"
-	Default_REDIS_LOCAL_TCP_PORT string = "localhost:6379"
 )
 
 // Client defines a set of methods which every client must implement.
@@ -325,7 +324,7 @@ func useRedisTcpClient() {
 			if UseRedisLocalTcpPort {
 				redisDb = redis.NewClient(&redis.Options{
 					Network:     "tcp",
-					Addr:        Default_REDIS_LOCAL_TCP_PORT,
+					Addr:        sdcfg.GetDbTcpAddr(dbName),
 					Password:    "", // no password set
 					DB:          int(dbn),
 					DialTimeout: 0,
@@ -345,7 +344,7 @@ func init() {
 
 			redisDb = redis.NewClient(&redis.Options{
 				Network:     "unix",
-				Addr:        Default_REDIS_UNIXSOCKET,
+				Addr:        sdcfg.GetDbSock(dbName),
 				Password:    "", // no password set
 				DB:          int(dbn),
 				DialTimeout: 0,

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -303,15 +303,7 @@ func GetTableKeySeparator(target string) (string, error) {
 		return "", fmt.Errorf("%v not a valid path target", target)
 	}
 
-	var separator string
-	switch target {
-	case "CONFIG_DB":
-		separator = "|"
-	case "STATE_DB":
-		separator = "|"
-	default:
-		separator = ":"
-	}
+	var separator string = sdcfg.GetDbSeparator(target)
 	return separator, nil
 }
 

--- a/sonic_db_config/db_config.go
+++ b/sonic_db_config/db_config.go
@@ -57,6 +57,18 @@ func GetDbSeparator(db_name string)(string) {
     return separator.(string)
 }
 
+func GetDbId(db_name string)(int) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    db_list := GetDbList()
+    id, ok := db_list[db_name].(map[string]interface{})["id"]
+    if !ok {
+        panic(fmt.Errorf("'id' is not a valid field in database_config.json file!"))
+    }
+    return int(id.(float64))
+}
+
 func GetDbSock(db_name string)(string) {
     if !sonic_db_init {
         DbInit()

--- a/sonic_db_config/db_config.go
+++ b/sonic_db_config/db_config.go
@@ -15,6 +15,17 @@ const (
 var sonic_db_config = make(map[string]interface{})
 var sonic_db_init bool
 
+func GetDbList()(map[string]interface{}) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    db_list, ok := sonic_db_config["DATABASES"].(map[string]interface{})
+    if !ok {
+        panic(fmt.Errorf("DATABASES' is not valid key in database_config.json file!"))
+    }
+    return db_list
+}
+
 func GetDbInst(db_name string)(map[string]interface{}) {
     if !sonic_db_init {
         DbInit()
@@ -32,6 +43,18 @@ func GetDbInst(db_name string)(map[string]interface{}) {
         panic(fmt.Errorf("instance name '%v' is not valid in database_config.json file!", inst_name))
     }
     return inst.(map[string]interface{})
+}
+
+func GetDbSeparator(db_name string)(string) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    db_list := GetDbList()
+    separator, ok := db_list[db_name].(map[string]interface{})["separator"]
+    if !ok {
+        panic(fmt.Errorf("'separator' is not a valid field in database_config.json file!"))
+    }
+    return separator.(string)
 }
 
 func GetDbSock(db_name string)(string) {

--- a/sonic_db_config/db_config.go
+++ b/sonic_db_config/db_config.go
@@ -1,0 +1,100 @@
+// Package dbconfig provides a generic functions for parsing sonic database config file in system
+package dbconfig
+
+import (
+    "encoding/json"
+    "fmt"
+    "strconv"
+    io "io/ioutil"
+)
+
+const (
+    SONIC_DB_CONFIG_FILE string = "/var/run/redis/sonic-db/database_config.json"
+)
+
+var sonic_db_config = make(map[string]interface{})
+var sonic_db_init bool
+
+func GetDbInst(db_name string)(map[string]interface{}) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    db, ok := sonic_db_config["DATABASES"].(map[string]interface{})[db_name]
+    if !ok {
+        panic(fmt.Errorf("database name '%v' is not valid in database_config.json file!", db_name))
+    }
+    inst_name, ok := db.(map[string]interface{})["instance"]
+    if !ok {
+        panic(fmt.Errorf("'instance' is not a valid field in database_config.json file!"))
+    }
+    inst, ok := sonic_db_config["INSTANCES"].(map[string]interface{})[inst_name.(string)]
+    if !ok {
+        panic(fmt.Errorf("instance name '%v' is not valid in database_config.json file!", inst_name))
+    }
+    return inst.(map[string]interface{})
+}
+
+func GetDbSock(db_name string)(string) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    inst := GetDbInst(db_name)
+    unix_socket_path, ok := inst["unix_socket_path"]
+    if !ok {
+        panic(fmt.Errorf("'unix_socket_path' is not a valid field in database_config.json file!"))
+    }
+    return unix_socket_path.(string)
+}
+
+func GetDbHostName(db_name string)(string) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    inst := GetDbInst(db_name)
+    hostname, ok := inst["hostname"]
+    if !ok {
+        panic(fmt.Errorf("'hostname' is not a valid field in database_config.json file!"))
+    }
+    return hostname.(string)
+}
+
+func GetDbPort(db_name string)(int) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    inst := GetDbInst(db_name)
+    port, ok := inst["port"]
+    if !ok {
+        panic(fmt.Errorf("'port' is not a valid field in database_config.json file!"))
+    }
+    return int(port.(float64))
+}
+
+func GetDbTcpAddr(db_name string)(string) {
+    if !sonic_db_init {
+        DbInit()
+    }
+    hostname := GetDbHostName(db_name)
+    port := GetDbPort(db_name)
+    return hostname + ":" + strconv.Itoa(port)
+}
+
+func DbInit() {
+    if sonic_db_init {
+        return
+    }
+    data, err := io.ReadFile(SONIC_DB_CONFIG_FILE)
+    if err != nil {
+        panic(err)
+    } else {
+        err = json.Unmarshal([]byte(data), &sonic_db_config)
+        if err != nil {
+            panic(err)
+        }
+        sonic_db_init = true
+    }
+}
+
+func init() {
+    sonic_db_init = false
+}

--- a/testdata/database_config.json
+++ b/testdata/database_config.json
@@ -1,0 +1,57 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port" : 6379,
+            "unix_socket_path" : "/var/run/redis/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}


### PR DESCRIPTION
* add new package to parse database_config.json file and provide get APIs
* replace hardcoded TCP/SOCK Addr with new Get Func()
* fix telemetry test cases which is not working before, when make deb pkg, test cases run will be triggered 

* all current testcases passed and on DUT, telemetry and dialout_client_cli are running
/usr/local/go/bin/go test -v /tmp/go/src/github.com/Azure/sonic-telemetry/gnmi_server
=== RUN   TestGnmiGet
=== RUN   TestGnmiGet/Test_non-existing_path_Target
=== RUN   TestGnmiGet/Test_empty_path_target
=== RUN   TestGnmiGet/Get_valid_but_non-existing_node
=== RUN   TestGnmiGet/Get_COUNTERS_PORT_NAME_MAP
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68_Pfcwd
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_Pfcwd
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*_Pfcwd
--- PASS: TestGnmiGet (4.40s)
    --- PASS: TestGnmiGet/Test_non-existing_path_Target (0.01s)
    --- PASS: TestGnmiGet/Test_empty_path_target (0.00s)
    --- PASS: TestGnmiGet/Get_valid_but_non-existing_node (0.00s)
    --- PASS: TestGnmiGet/Get_COUNTERS_PORT_NAME_MAP (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68 (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68_Pfcwd (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1 (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_Pfcwd (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet* (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet*_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet*_Pfcwd (0.00s)
=== RUN   TestGnmiSubscribe
=== RUN   TestGnmiSubscribe/stream_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_test_field_field
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet68_with_new_test_field_field
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_table_key_Ethernet68/1_with_new_test_field_field
=== RUN   TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value
=== RUN   TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/Pfcwd_with_update_of_field_value
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_update_of_field_value
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*_with_new_test_field_field_on_Ethernet68
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_update
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/Pfcwd_with_field_value_update
=== RUN   TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_field_test_field
=== RUN   TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_test_field_delete
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Pfcwd_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_Ethernet*_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_field_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_field_Etherenet*/Pfcwd_with_Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet*/Queues
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change
--- PASS: TestGnmiSubscribe (76.84s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_test_field_field (2.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet68_with_new_test_field_field (3.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_table_key_Ethernet68/1_with_new_test_field_field (3.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/Pfcwd_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*_with_new_test_field_field_on_Ethernet68 (3.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_update (2.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/Pfcwd_with_field_value_update (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_field_test_field (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_test_field_delete (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Pfcwd_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_Ethernet*_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_field_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_field_Etherenet*/Pfcwd_with_Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED_field_value_change (2.02s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet*/Queues (1.05s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change (2.01s)
PASS
ok  	github.com/Azure/sonic-telemetry/gnmi_server	(cached)
/usr/local/go/bin/go get -v -t github.com/Azure/sonic-telemetry/dialout/dialout_client/...
github.com/google/gnxi (download)
/usr/local/go/bin/go test -v /tmp/go/src/github.com/Azure/sonic-telemetry/dialout/dialout_client
=== RUN   TestGNMIDialOutPublish
=== RUN   TestGNMIDialOutPublish/DialOut_to_first_collector_in_stream_mode_and_synced
=== RUN   TestGNMIDialOutPublish/DialOut_to_second_collector_in_stream_mode_upon_failure_of_first_collector
--- PASS: TestGNMIDialOutPublish (19.58s)
    --- PASS: TestGNMIDialOutPublish/DialOut_to_first_collector_in_stream_mode_and_synced (0.52s)
    --- PASS: TestGNMIDialOutPublish/DialOut_to_second_collector_in_stream_mode_upon_failure_of_first_collector (7.52s)
PASS
ok  	github.com/Azure/sonic-telemetry/dialout/dialout_client	(cached)


Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com