### PR TITLE
Fix Ctrl+C to terminate dialout_client_cli

### DIFF
--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -696,6 +696,13 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 	}
 
 	for {
+		// Check if ctx was canceled.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		
 		msgi, err := pubsub.ReceiveTimeout(time.Millisecond * 1000)
 		if err != nil {
 			neterr, ok := err.(net.Error)
@@ -716,12 +723,6 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 		} else {
 			log.V(2).Infof("Invalid psubscribe payload notification:  %v", subscr)
 			continue
-		}
-		// Check if ctx was canceled.
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
 		}
 	}
 }


### PR DESCRIPTION
Ctrl+C cannot terminate dialout_client_cli until dialout_client received the Redis Pub/Sub message.

The reason is that the code to check the ctx.Done() is behind the code to receive message.

Therefore, I move the checking code in order to terminate the program even if there is no Redis Pub/Sub message received.