### PR TITLE
Add read-only mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
 TEST_FILES=$(wildcard *_test.go)
 TELEMETRY_TEST_DIR = $(GO_MGMT_PATH)/build/tests/gnmi_server
 TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
+ifeq ($(TELEMETRY_READONLY),y)
+BLD_FLAGS := -tags readonly
+endif
 
 .phony: mgmt-deps
 
@@ -60,7 +63,7 @@ mgmt-deps:
 	make -C $(GO_MGMT_PATH)/models/yang/sonic
 
 sonic-telemetry: go.mod mgmt-deps
-	$(GO) install -mod=vendor github.com/Azure/sonic-telemetry/telemetry
+	$(GO) install -mod=vendor $(BLD_FLAGS) github.com/Azure/sonic-telemetry/telemetry
 	$(GO) install -mod=vendor github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 	$(GO) install github.com/jipanyang/gnxi/gnmi_get
 	$(GO) install github.com/jipanyang/gnxi/gnmi_set

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
 TEST_FILES=$(wildcard *_test.go)
 TELEMETRY_TEST_DIR = $(GO_MGMT_PATH)/build/tests/gnmi_server
 TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
-ifeq ($(TELEMETRY_READWRITE),y)
+ifeq ($(SONIC_TELEMETRY_READWRITE),y)
 BLD_FLAGS := -tags readwrite
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
 TEST_FILES=$(wildcard *_test.go)
 TELEMETRY_TEST_DIR = $(GO_MGMT_PATH)/build/tests/gnmi_server
 TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
-ifeq ($(TELEMETRY_READONLY),y)
-BLD_FLAGS := -tags readonly
+ifeq ($(TELEMETRY_READWRITE),y)
+BLD_FLAGS := -tags readwrite
 endif
 
 .phony: mgmt-deps

--- a/gnmi_server/constants.go
+++ b/gnmi_server/constants.go
@@ -1,5 +1,5 @@
-// +build !readonly
+// +build !readwrite
 
 package gnmi
 
-const READ_ONLY_MODE = false
+const READ_WRITE_MODE = false

--- a/gnmi_server/constants.go
+++ b/gnmi_server/constants.go
@@ -1,0 +1,5 @@
+// +build !readonly
+
+package gnmi
+
+const READ_ONLY_MODE = false

--- a/gnmi_server/constants_readonly.go
+++ b/gnmi_server/constants_readonly.go
@@ -1,5 +1,0 @@
-// +build readonly
-
-package gnmi
-
-const READ_ONLY_MODE = true

--- a/gnmi_server/constants_readonly.go
+++ b/gnmi_server/constants_readonly.go
@@ -1,0 +1,5 @@
+// +build readonly
+
+package gnmi
+
+const READ_ONLY_MODE = true

--- a/gnmi_server/constants_readwrite.go
+++ b/gnmi_server/constants_readwrite.go
@@ -1,0 +1,5 @@
+// +build readwrite
+
+package gnmi
+
+const READ_WRITE_MODE = true

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -64,7 +64,7 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 		return nil, fmt.Errorf("failed to open listener port %d: %v", srv.config.Port, err)
 	}
 	gnmipb.RegisterGNMIServer(srv.s, srv)
-	log.V(1).Infof("Created Server on %s", srv.Address())
+	log.V(1).Infof("Created Server on %s, read-only: %t", srv.Address(), !READ_WRITE_MODE)
 	return srv, nil
 }
 
@@ -209,7 +209,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 }
 
 func (srv *Server) Set(ctx context.Context,req *gnmipb.SetRequest) (*gnmipb.SetResponse, error) {
-		if READ_ONLY_MODE {
+		if !READ_WRITE_MODE {
 			return nil, grpc.Errorf(codes.Unimplemented, "Telemetry is in read-only mode")
 		}
 		var results []*gnmipb.UpdateResult

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c h1:a380JP+B7xlMbEQOlha1buKhzBPXFqgFXplyWCEIGEY=
 github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c/go.mod h1:t+O9It+LKzfOAhKTT5O0ehDix+MTqbtT0T9t+7zzOvc=
+github.com/openconfig/gnmi v0.0.0-20200307010808-e7106f7f5493 h1:e/znXbq+Yiws97a4lJYlUeRw9OGxT2q27L4aMUb0GuM=
 github.com/openconfig/goyang v0.0.0-20190924211109-064f9690516f h1:BaekRUaWpfaRBP3mShDZaNi4+EHbdli7D6YXc/TP3lo=
 github.com/openconfig/goyang v0.0.0-20190924211109-064f9690516f/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=
 github.com/openconfig/ygot v0.6.0 h1:kJJFPBrczC6TDnz/HMlFTJEdW2CuyUftV13XveIukg0=


### PR DESCRIPTION
Check for file /etc/sonic/telemetry_readonly and if it exists, gNMI set will be disabled.