### PR TITLE
Skip gNMI Set tests in read-only mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ mgmt-deps:
 
 sonic-telemetry: go.mod mgmt-deps
 	$(GO) install -mod=vendor $(BLD_FLAGS) github.com/Azure/sonic-telemetry/telemetry
-	$(GO) install -mod=vendor github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
+	$(GO) install -mod=vendor $(BLD_FLAGS) github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 	$(GO) install github.com/jipanyang/gnxi/gnmi_get
 	$(GO) install github.com/jipanyang/gnxi/gnmi_set
 	$(GO) install -mod=vendor github.com/openconfig/gnmi/cmd/gnmi_cli
@@ -74,8 +74,8 @@ check:
 	sudo cp ./testdata/database_config.json ${DBDIR}
 	sudo mkdir -p /usr/models/yang || true
 	sudo find $(GO_MGMT_PATH)/models -name '*.yang' -exec cp {} /usr/models/yang/ \;
-	-$(GO) test -mod=vendor -v github.com/Azure/sonic-telemetry/gnmi_server
-	-$(GO) test -mod=vendor -v github.com/Azure/sonic-telemetry/dialout/dialout_client
+	-$(GO) test -mod=vendor $(BLD_FLAGS) -v github.com/Azure/sonic-telemetry/gnmi_server
+	-$(GO) test -mod=vendor $(BLD_FLAGS) -v github.com/Azure/sonic-telemetry/dialout/dialout_client
 
 clean:
 	rm -rf cvl
@@ -86,7 +86,7 @@ clean:
 	rm -f src
 
 $(TELEMETRY_TEST_BIN): $(TEST_FILES) $(SRC_FILES)
-	$(GO) test -mod=vendor -c -cover github.com/Azure/sonic-telemetry/gnmi_server -o $@
+	$(GO) test -mod=vendor $(BLD_FLAGS) -c -cover github.com/Azure/sonic-telemetry/gnmi_server -o $@
 	cp -r testdata $(TELEMETRY_TEST_DIR)
 	cp -r $(GO_MGMT_PATH)/src/cvl/schema $(TELEMETRY_TEST_DIR)
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -413,7 +413,9 @@ func prepareDbTranslib(t *testing.T) {
 }
 
 func TestGnmiSet(t *testing.T) {
-	//t.Log("Start server")
+	if !READ_WRITE_MODE {
+		t.Skip("skipping test in read-only mode.")
+	}
 	s := createServer(t)
 	go runServer(t, s)
 


### PR DESCRIPTION
Test results in read-only mode:
```
=== RUN   TestGnmiSet
--- SKIP: TestGnmiSet (0.00s)
    server_test.go:417: skipping test in read-only mode.
=== RUN   TestGnmiGet
=== RUN   TestGnmiGet/Test_non-existing_path_Target
E0414 23:45:05.167835      35 app_interface.go:143] Unsupported path=/MyCounters
=== RUN   TestGnmiGet/Test_empty_path_target
=== RUN   TestGnmiGet/Get_valid_but_non-existing_node
=== RUN   TestGnmiGet/Get_COUNTERS_PORT_NAME_MAP
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68_Pfcwd
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_Pfcwd
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*_Pfcwd
--- PASS: TestGnmiGet (2.33s)
    --- PASS: TestGnmiGet/Test_non-existing_path_Target (0.01s)
    --- PASS: TestGnmiGet/Test_empty_path_target (0.00s)
    --- PASS: TestGnmiGet/Get_valid_but_non-existing_node (0.01s)
    --- PASS: TestGnmiGet/Get_COUNTERS_PORT_NAME_MAP (0.01s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68 (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68_Pfcwd (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1 (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_Pfcwd (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet* (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet*_SAI_PORT_STAT_PFC_7_RX_PKTS (0.02s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet*_Pfcwd (0.01s)
=== RUN   TestGnmiGetTranslib
=== RUN   TestGnmiGetTranslib/Get_OC_Interfaces
=== RUN   TestGnmiGetTranslib/Get_OC_Interface
=== RUN   TestGnmiGetTranslib/Get_OC_Interface_admin-status
=== RUN   TestGnmiGetTranslib/Get_OC_Interface_ifindex
=== RUN   TestGnmiGetTranslib/Get_OC_Interface_mtu
--- PASS: TestGnmiGetTranslib (6.44s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interfaces (0.66s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface (0.01s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface_admin-status (0.00s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface_ifindex (0.00s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface_mtu (0.00s)
=== RUN   TestGnmiSubscribe
=== RUN   TestGnmiSubscribe/stream_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_test_field_field
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet68_with_new_test_field_field
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_table_key_Ethernet68/1_with_new_test_field_field
=== RUN   TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value
=== RUN   TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/Pfcwd_with_update_of_field_value
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_update_of_field_value
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*_with_new_test_field_field_on_Ethernet68
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_update
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/Pfcwd_with_field_value_update
=== RUN   TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_field_test_field
=== RUN   TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_test_field_delete
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Pfcwd_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_Ethernet*_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_field_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_field_Etherenet*/Pfcwd_with_Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet*/Queues
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change
--- PASS: TestGnmiSubscribe (76.15s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_test_field_field (2.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet68_with_new_test_field_field (3.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_table_key_Ethernet68/1_with_new_test_field_field (3.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value (3.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/Pfcwd_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_update_of_field_value (3.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*_with_new_test_field_field_on_Ethernet68 (3.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_update (2.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/Pfcwd_with_field_value_update (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_field_test_field (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_test_field_delete (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Pfcwd_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_Ethernet*_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change (2.02s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_field_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change (2.02s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_field_Etherenet*/Pfcwd_with_Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED_field_value_change (2.03s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet*/Queues (1.08s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change (2.02s)
=== RUN   TestCapabilities
--- PASS: TestCapabilities (4.05s)
PASS
coverage: 68.7% of statements

```
Test results in read-write mode:
```
=== RUN   TestGnmiSet
=== RUN   TestGnmiSet/Set_OC_Interface_MTU
=== RUN   TestGnmiSet/Set_OC_Interface_IP
=== RUN   TestGnmiSet/Delete_OC_Interface_IP
--- PASS: TestGnmiSet (2.75s)
    --- PASS: TestGnmiSet/Set_OC_Interface_MTU (0.02s)
    --- PASS: TestGnmiSet/Set_OC_Interface_IP (0.00s)
    --- PASS: TestGnmiSet/Delete_OC_Interface_IP (0.00s)
=== RUN   TestGnmiGet
=== RUN   TestGnmiGet/Test_non-existing_path_Target
E0415 00:12:25.242896     147 app_interface.go:143] Unsupported path=/MyCounters
=== RUN   TestGnmiGet/Test_empty_path_target
=== RUN   TestGnmiGet/Get_valid_but_non-existing_node
=== RUN   TestGnmiGet/Get_COUNTERS_PORT_NAME_MAP
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet68_Pfcwd
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_Pfcwd
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*_SAI_PORT_STAT_PFC_7_RX_PKTS
=== RUN   TestGnmiGet/get_COUNTERS:Ethernet*_Pfcwd
--- PASS: TestGnmiGet (3.05s)
    --- PASS: TestGnmiGet/Test_non-existing_path_Target (0.02s)
    --- PASS: TestGnmiGet/Test_empty_path_target (0.00s)
    --- PASS: TestGnmiGet/Get_valid_but_non-existing_node (0.01s)
    --- PASS: TestGnmiGet/Get_COUNTERS_PORT_NAME_MAP (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68 (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet68_Pfcwd (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1 (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS_(use_vendor_alias):Ethernet68/1_Pfcwd (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet* (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet*_SAI_PORT_STAT_PFC_7_RX_PKTS (0.00s)
    --- PASS: TestGnmiGet/get_COUNTERS:Ethernet*_Pfcwd (0.01s)
=== RUN   TestGnmiGetTranslib
=== RUN   TestGnmiGetTranslib/Get_OC_Interfaces
=== RUN   TestGnmiGetTranslib/Get_OC_Interface
=== RUN   TestGnmiGetTranslib/Get_OC_Interface_admin-status
=== RUN   TestGnmiGetTranslib/Get_OC_Interface_ifindex
=== RUN   TestGnmiGetTranslib/Get_OC_Interface_mtu
--- PASS: TestGnmiGetTranslib (5.81s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interfaces (0.48s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface (0.00s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface_admin-status (0.00s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface_ifindex (0.00s)
    --- PASS: TestGnmiGetTranslib/Get_OC_Interface_mtu (0.00s)
=== RUN   TestGnmiSubscribe
=== RUN   TestGnmiSubscribe/stream_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_test_field_field
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet68_with_new_test_field_field
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_table_key_Ethernet68/1_with_new_test_field_field
=== RUN   TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value
=== RUN   TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/Pfcwd_with_update_of_field_value
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_update_of_field_value
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*_with_new_test_field_field_on_Ethernet68
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_update
=== RUN   TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/Pfcwd_with_field_value_update
=== RUN   TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_field_test_field
=== RUN   TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_test_field_delete
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Pfcwd_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_Ethernet*_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_field_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_table_key_field_Etherenet*/Pfcwd_with_Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED_field_value_change
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet*/Queues
=== RUN   TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change
=== RUN   TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change
--- PASS: TestGnmiSubscribe (79.63s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_test_field_field (2.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet68_with_new_test_field_field (3.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_table_key_Ethernet68/1_with_new_test_field_field (3.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value (3.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_update_of_field_value (3.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_COUNTERS/Ethernet68/Pfcwd_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_stream_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_update_of_field_value (3.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*_with_new_test_field_field_on_Ethernet68 (3.01s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_update (2.00s)
    --- PASS: TestGnmiSubscribe/stream_query_for_table_key_Ethernet*/Pfcwd_with_field_value_update (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_new_field_test_field (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_COUNTERS_PORT_NAME_MAP_with_test_field_delete (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Pfcwd_with_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/[Ethernet68/1]/Pfcwd_with_field_value_change (2.00s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_Ethernet*_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change (2.02s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_field_Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS_with_Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/poll_query_for_table_key_field_Etherenet*/Pfcwd_with_Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED_field_value_change (2.04s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet*/Queues (1.12s)
    --- PASS: TestGnmiSubscribe/poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change (2.01s)
    --- PASS: TestGnmiSubscribe/(use_vendor_alias)_poll_query_for_COUNTERS/Ethernet68/Queues_with_field_value_change (2.01s)
=== RUN   TestCapabilities
--- PASS: TestCapabilities (3.32s)
PASS
coverage: 76.5% of statements

```