### PR TITLE
Disregarding EOF status for STREAM subs.

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/golang/glog"
 	"github.com/Workiva/go-datastructures/queue"
+	log "github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -118,19 +118,18 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	}
 	var dc sdc.Client
 
-    if target == "OTHERS" {
-            dc, err = sdc.NewNonDbClient(paths, prefix)
-    } else if isTargetDb(target) == true {
-            dc, err = sdc.NewDbClient(paths, prefix)
-    } else {
-            /* For any other target or no target create new Transl Client. */
-            dc, err = sdc.NewTranslClient(prefix, paths)
-    }
+	if target == "OTHERS" {
+		dc, err = sdc.NewNonDbClient(paths, prefix)
+	} else if isTargetDb(target) == true {
+		dc, err = sdc.NewDbClient(paths, prefix)
+	} else {
+		/* For any other target or no target create new Transl Client. */
+		dc, err = sdc.NewTranslClient(prefix, paths)
+	}
 
-    if err != nil {
-            return grpc.Errorf(codes.NotFound, "%v", err)
-    }
-
+	if err != nil {
+		return grpc.Errorf(codes.NotFound, "%v", err)
+	}
 
 	switch mode := c.subscribe.GetMode(); mode {
 	case gnmipb.SubscriptionList_STREAM:
@@ -154,6 +153,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	log.V(1).Infof("Client %s running", c)
 	go c.recv(stream)
 	err = c.send(stream)
+
 	c.Close()
 	// Wait until all child go routines exited
 	c.w.Wait()
@@ -189,6 +189,7 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 
 	for {
 		log.V(5).Infof("Client %s blocking on stream.Recv()", c)
+
 		event, err := stream.Recv()
 		c.recvMsg++
 
@@ -198,6 +199,17 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 			return
 		case io.EOF:
 			log.V(1).Infof("Client %s received io.EOF", c)
+
+			if c.subscribe.Mode == gnmipb.SubscriptionList_STREAM {
+				// The client->server could be closed after the sending the subscription list.
+				// EOF is not a indication of client is not listening.
+				// Instead stream.Context() which is signaled once the underlying connection is terminated.
+				log.V(1).Infof("Waiting for client '%s'", c)
+				// This context is done when the client connection is terminated.
+				<-stream.Context().Done()
+				log.V(1).Infof("Client is done '%s'", c)
+			}
+
 			return
 		case nil:
 		}

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -153,7 +153,6 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	log.V(1).Infof("Client %s running", c)
 	go c.recv(stream)
 	err = c.send(stream)
-
 	c.Close()
 	// Wait until all child go routines exited
 	c.w.Wait()
@@ -189,7 +188,6 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 
 	for {
 		log.V(5).Infof("Client %s blocking on stream.Recv()", c)
-
 		event, err := stream.Recv()
 		c.recvMsg++
 
@@ -199,7 +197,6 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 			return
 		case io.EOF:
 			log.V(1).Infof("Client %s received io.EOF", c)
-
 			if c.subscribe.Mode == gnmipb.SubscriptionList_STREAM {
 				// The client->server could be closed after the sending the subscription list.
 				// EOF is not a indication of client is not listening.
@@ -209,7 +206,6 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 				<-stream.Context().Done()
 				log.V(1).Infof("Client is done '%s'", c)
 			}
-
 			return
 		case nil:
 		}


### PR DESCRIPTION
The `client->server` stream is not used after sending the subscription list for stream mode subscriptions. Hence closure of that stream is not indicator of end of subscription. Instead check `stream.Context()` which is signaled once the underlying connection is terminated. 

Also see the example service logs and annotations: 
[service-logs.txt](https://github.com/Azure/sonic-telemetry/files/5519332/service-logs.txt)

For testing see the client response output for an `ON_CHANGE` subscription with query `COUNTERS/Ethernet1`:
- Using gnmi_cli: [gnmi_cli-output.txt](https://github.com/Azure/sonic-telemetry/files/5534348/gnmi_cli-output.txt)
- Using py_gnmicli.py: [py_gnmicli-output.txt](https://github.com/Azure/sonic-telemetry/files/5534351/py_gnmicli-output.txt)
- Using C# client: [dotnet_cli-output.txt](https://github.com/Azure/sonic-telemetry/files/5540053/dotnet_cli-output.txt)




