### PR TITLE
[dataset] Add dataset "system uptime" into non-db client.

### DIFF
--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -251,8 +251,8 @@ func getProcStat() ([]byte, error) {
 }
 
 func getSysUptime() ([]byte, error) {
-    timeInfo, _ := linuxproc.ReadUptime("/proc/uptime")
-    b, err := json.Marshal(timeInfo)
+    sysUptime, _ := linuxproc.ReadUptime("/proc/uptime")
+    b, err := json.Marshal(sysUptime)
     if err != nil {
         log.V(2).Infof("%v", err)
         return b, err

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -63,6 +63,10 @@ var (
 			path:    []string{"OTHERS", "proc", "stat"},
 			getFunc: dataGetFunc(getProcStat),
 		},
+		{ // Get host uptime
+			path:    []string{"OTHERS", "platform", "sysuptime"},
+			getFunc: dataGetFunc(getSysUptime),
+		},
 	}
 )
 
@@ -92,6 +96,12 @@ type cpuUtil struct {
 	CpuUtil_1min  uint64 `json:"1min"`
 	CpuUtil_5min  uint64 `json:"5min"`
 }
+
+// SONiC Host system uptime
+type sysUptime struct {
+    Total   uint64 `json:"total"`
+}
+
 
 func getCpuUtilPercents(cur, last *linuxproc.CPUStat) uint64 {
 	curTotal := (cur.User + cur.Nice + cur.System + cur.Idle + cur.IOWait + cur.IRQ + cur.SoftIRQ + cur.Steal + cur.Guest + cur.GuestNice)
@@ -245,6 +255,21 @@ func getProcStat() ([]byte, error) {
 	log.V(4).Infof("getProcStat, output %v", string(b))
 	return b, nil
 }
+
+func getSysUptime() ([]byte, error) {
+	timeInfo, _ := linuxproc.ReadUptime("/proc/uptime")
+    uptime := sysUptime{}
+    uptime.Total = uint64(timeInfo.Total)
+	b, err := json.Marshal(uptime)
+	if err != nil {
+		log.V(2).Infof("%v", err)
+		return b, err
+	}
+
+	log.V(4).Infof("getSysUptime, output %v", string(b))
+	return b, nil
+}
+
 
 func pollStats() {
 	for {

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -43,6 +43,10 @@ var (
 			path:    []string{"OTHERS", "platform", "cpu"},
 			getFunc: dataGetFunc(getCpuUtil),
 		},
+		{ // Get host uptime
+			path:    []string{"OTHERS", "platform", "sysuptime"},
+			getFunc: dataGetFunc(getSysUptime),
+		},
 		{ // Get proc meminfo
 			path:    []string{"OTHERS", "proc", "meminfo"},
 			getFunc: dataGetFunc(getProcMeminfo),
@@ -62,10 +66,6 @@ var (
 		{ // Get proc stat
 			path:    []string{"OTHERS", "proc", "stat"},
 			getFunc: dataGetFunc(getProcStat),
-		},
-		{ // Get host uptime
-			path:    []string{"OTHERS", "platform", "sysuptime"},
-			getFunc: dataGetFunc(getSysUptime),
 		},
 	}
 )

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -257,10 +257,10 @@ func getProcStat() ([]byte, error) {
 }
 
 func getSysUptime() ([]byte, error) {
-	timeInfo, _ := linuxproc.ReadUptime("/proc/uptime")
+    timeInfo, _ := linuxproc.ReadUptime("/proc/uptime")
     uptime := sysUptime{}
     uptime.Total = uint64(timeInfo.Total)
-	b, err := json.Marshal(uptime)
+    b, err := json.Marshal(uptime)
 	if err != nil {
 		log.V(2).Infof("%v", err)
 		return b, err

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -102,7 +102,6 @@ type sysUptime struct {
     Total   uint64 `json:"total"`
 }
 
-
 func getCpuUtilPercents(cur, last *linuxproc.CPUStat) uint64 {
 	curTotal := (cur.User + cur.Nice + cur.System + cur.Idle + cur.IOWait + cur.IRQ + cur.SoftIRQ + cur.Steal + cur.Guest + cur.GuestNice)
 	lastTotal := (last.User + last.Nice + last.System + last.Idle + last.IOWait + last.IRQ + last.SoftIRQ + last.Steal + last.Guest + last.GuestNice)
@@ -261,15 +260,14 @@ func getSysUptime() ([]byte, error) {
     uptime := sysUptime{}
     uptime.Total = uint64(timeInfo.Total)
     b, err := json.Marshal(uptime)
-	if err != nil {
-		log.V(2).Infof("%v", err)
-		return b, err
-	}
+    if err != nil {
+        log.V(2).Infof("%v", err)
+        return b, err
+    }
 
-	log.V(4).Infof("getSysUptime, output %v", string(b))
-	return b, nil
+    log.V(4).Infof("getSysUptime, output %v", string(b))
+    return b, nil
 }
-
 
 func pollStats() {
 	for {

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -44,7 +44,7 @@ var (
 			getFunc: dataGetFunc(getCpuUtil),
 		},
 		{ // Get host uptime
-			path:    []string{"OTHERS", "proc", "sysuptime"},
+			path:    []string{"OTHERS", "proc", "uptime"},
 			getFunc: dataGetFunc(getSysUptime),
 		},
 		{ // Get proc meminfo

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -251,8 +251,8 @@ func getProcStat() ([]byte, error) {
 }
 
 func getSysUptime() ([]byte, error) {
-    sysUptime, _ := linuxproc.ReadUptime("/proc/uptime")
-    b, err := json.Marshal(sysUptime)
+    uptime, _ := linuxproc.ReadUptime("/proc/uptime")
+    b, err := json.Marshal(uptime)
     if err != nil {
         log.V(2).Infof("%v", err)
         return b, err

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -44,7 +44,7 @@ var (
 			getFunc: dataGetFunc(getCpuUtil),
 		},
 		{ // Get host uptime
-			path:    []string{"OTHERS", "platform", "sysuptime"},
+			path:    []string{"OTHERS", "proc", "sysuptime"},
 			getFunc: dataGetFunc(getSysUptime),
 		},
 		{ // Get proc meminfo
@@ -95,11 +95,6 @@ type cpuUtil struct {
 	CpuUtil_5s    uint64 `json:"5s"`
 	CpuUtil_1min  uint64 `json:"1min"`
 	CpuUtil_5min  uint64 `json:"5min"`
-}
-
-// SONiC Host system uptime
-type sysUptime struct {
-    Total   uint64 `json:"total"`
 }
 
 func getCpuUtilPercents(cur, last *linuxproc.CPUStat) uint64 {
@@ -257,9 +252,7 @@ func getProcStat() ([]byte, error) {
 
 func getSysUptime() ([]byte, error) {
     timeInfo, _ := linuxproc.ReadUptime("/proc/uptime")
-    uptime := sysUptime{}
-    uptime.Total = uint64(timeInfo.Total)
-    b, err := json.Marshal(uptime)
+    b, err := json.Marshal(timeInfo)
     if err != nil {
         log.V(2).Infof("%v", err)
         return b, err


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

1. Motivation of this PR:
This PR aims to enable the streaming telemetry container to stream out the `system uptime` of SONiC Host. This dataset is added into non-database client since it is a kind of value which will be refreshed periodically.

2. How can I do that?
I follow the example of dataset in non-database client such as `meminfo` to do the implementation. The data source of `system uptime` is from the file `/proc/uptime` on the SONiC host.

    We can use the command `./gnmi_cli -client_types=gnmi -a <DuT_IP>:8080 -t OTHERS -logtostderr -insecure -qt p -pi 10s -q proc/uptime` to query the `system uptime` every 10 seconds.  

    admin@str-a7050-acs-3:~$ ./gnmi_cli -client_types=gnmi -a localhost:8080 -t OTHERS -logtostderr -insecure -qt p -pi 10s -q proc/uptime
\{
    "OTHERS": {
        "proc": {
            "uptime": "{\"total\":314.74,\"idle\":981.27}"
         }
     }
}
{
    "OTHERS": {
        "proc": {
          "uptime": "{\"total\":324.74,\"idle\":1016.85}"
        }
    }
}
