### PR TITLE
[sonic-telemetry] Fix the bug that the old fvs may be overriden in makeJSON.

### DIFF
--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -500,6 +500,25 @@ func makeJSON_redis(msi *map[string]interface{}, key *string, op *string, mfv ma
 	}
 
 	fp := map[string]interface{}{}
+
+	if key == nil {
+		if (*msi)[*op] != nil {
+			fp = (*msi)[*op].(map[string]interface{})
+		}
+	} else if op == nil {
+		if (*msi)[*key] != nil {
+			fp = (*msi)[*key].(map[string]interface{})
+		}
+	} else {
+		of_old := map[string]interface{}{}
+		if (*msi)[*key] != nil {
+			of_old = (*msi)[*key].(map[string]interface{})
+			if of_old[*op] != nil {
+				fp = of_old[*op].(map[string]interface{})
+			}
+		}
+	}
+
 	for f, v := range mfv {
 		fp[f] = v
 	}


### PR DESCRIPTION
Signed-off-by: sundandan <sundandan@asterfusion.com>

**- Why I did it**
As different `tablePath` may have the same `dbName`,`tableName`,`tableKey`, `delimitor` and the different `field`, and the function `makeJSON_redis` would be call many times with the same `msi`, `key`, `op` and the different `mfv`. Now, the logic makes the old fvs are overriden.

**- How I did it**
Get old `fvs` before assigning the new `mfvs` to `msi`.