### PR TITLE
Locking openconfig/gnmi version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ go.mod:
 $(GO_DEPS): go.mod $(PATCHES)
 	# FIXME temporary workaround for crypto not downloading..
 	$(GO) get golang.org/x/crypto/ssh/terminal@e9b2fee46413
+	$(GO) get github.com/openconfig/gnmi@d2b4e6a45802a75b3571a627519cae85a197fdda
 	$(GO) mod vendor
 	$(MGMT_COMMON_DIR)/patches/apply.sh vendor
 	cp -r $(GOPATH)/pkg/mod/golang.org/x/crypto@v0.0.0-20191206172530-e9b2fee46413 vendor/golang.org/x/crypto


### PR DESCRIPTION
The recent changes on the `openconfig/gnmi` caused a build break on `sonic/telemetry` repo. Making sure that `go.mod` is generated with the expected version of that library.