### PR TITLE
Support NonTLS option for testing purpose only.

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -34,9 +34,9 @@ func main() {
 		return
 	}
 
-	// var opts []grpc.ServerOption
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
+	var opts []grpc.ServerOption
 
 	if !*noTLS {
 		var certificate tls.Certificate
@@ -99,7 +99,7 @@ func main() {
 		tlsCfg.ClientCAs = certPool
 	}
 
-	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
+	opts = []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
 }
 
 	s, err := gnmi.NewServer(cfg, opts)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -41,36 +41,35 @@ func main() {
 	if !*noTLS {
 		var certificate tls.Certificate
 		var err error
-
-	if *insecure {
-
-		certificate, err = testcert.NewCert()
-		if err != nil {
-			log.Exitf("could not load server key pair: %s", err)
+		if *insecure {
+			certificate, err = testcert.NewCert()
+			if err != nil {
+				log.Exitf("could not load server key pair: %s", err)
+			}
 		}
-	} else {
-		switch {
-		case *serverCert == "":
-			log.Errorf("serverCert must be set.")
-			return
-		case *serverKey == "":
-			log.Errorf("serverKey must be set.")
-			return
+		else {
+			switch {
+			case *serverCert == "":
+				log.Errorf("serverCert must be set.")
+				return
+			case *serverKey == "":
+				log.Errorf("serverKey must be set.")
+				return
+			}
+			certificate, err = tls.LoadX509KeyPair(*serverCert, *serverKey)
+			if err != nil {
+				log.Exitf("could not load server key pair: %s", err)
+			}
 		}
-		certificate, err = tls.LoadX509KeyPair(*serverCert, *serverKey)
-		if err != nil {
-			log.Exitf("could not load server key pair: %s", err)
-		}
-	}
 
-	tlsCfg := &tls.Config{
+		tlsCfg := &tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{certificate},
 		MinVersion:               tls.VersionTLS12,
 		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-
+		CipherSuites: []uint16
+		{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
@@ -78,8 +77,8 @@ func main() {
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		},
-
 	}
+
 	if *allowNoClientCert {
 		// RequestClientCert will ask client for a certificate but won't
 		// require it to proceed. If certificate is provided, it will be

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -46,15 +46,14 @@ func main() {
 			if err != nil {
 				log.Exitf("could not load server key pair: %s", err)
 			}
-		}
-		else {
-			switch {
-			case *serverCert == "":
-				log.Errorf("serverCert must be set.")
-				return
-			case *serverKey == "":
-				log.Errorf("serverKey must be set.")
-				return
+		} else {
+			 switch {
+			   case *serverCert == "":
+				  log.Errorf("serverCert must be set.")
+				  return
+			   case *serverKey == "":
+				  log.Errorf("serverKey must be set.")
+				  return
 			}
 			certificate, err = tls.LoadX509KeyPair(*serverCert, *serverKey)
 			if err != nil {
@@ -68,8 +67,7 @@ func main() {
 		MinVersion:               tls.VersionTLS12,
 		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 		PreferServerCipherSuites: true,
-		CipherSuites: []uint16
-		{
+		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -21,7 +21,7 @@ var (
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
-	noTLS            = flag.Bool("noTLS", false, "disable TLS, for testing only!")
+	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 )
 
@@ -34,7 +34,7 @@ func main() {
 		return
 	}
 
-	var opts []grpc.ServerOption
+	// var opts []grpc.ServerOption
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -21,6 +21,7 @@ var (
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
+	noTLS            = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 )
 
@@ -32,10 +33,17 @@ func main() {
 		log.Errorf("port must be > 0.")
 		return
 	}
-	var certificate tls.Certificate
-	var err error
+
+	var opts []grpc.ServerOption
+	cfg := &gnmi.Config{}
+	cfg.Port = int64(*port)
+
+	if !*noTLS {
+		var certificate tls.Certificate
+		var err error
 
 	if *insecure {
+
 		certificate, err = testcert.NewCert()
 		if err != nil {
 			log.Exitf("could not load server key pair: %s", err)
@@ -92,8 +100,8 @@ func main() {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &gnmi.Config{}
-	cfg.Port = int64(*port)
+}
+
 	s, err := gnmi.NewServer(cfg, opts)
 	if err != nil {
 		log.Errorf("Failed to create gNMI server: %v", err)


### PR DESCRIPTION
Introduce new flag "noTLS" on server side to support non TLS option, for testing purpose only.

Why this change?
Need to support nonTLS option on server so that c# client can connect over http.

How did I test it?
Tests done:
**Server end:**
![image](https://user-images.githubusercontent.com/49077256/106558602-e30e2280-64d8-11eb-8535-dfa92ee7e8f4.png)

**Gnmi client:**
root@f66f87ca51c3:/src/telemetry_standalone/sonic-telemetry/build/bin# ./gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr localhost:8080 -notls          
== getRequest:
prefix: <
  target: "COUNTERS_DB"
>
path: <
  elem: <
    name: "COUNTERS"
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1612243637789570057
  prefix: <
    target: "COUNTERS_DB"
  >
  update: <
    path: <
      elem: <
        name: "COUNTERS"
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS\":\"0\",\"SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS\":\"0\",\"SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS\":\"0\",\"SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_BROADCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_DISCARDS\":\"0\",\"SAI_PORT_STAT_IF_IN_ERRORS\":\"0\",\"SAI_PORT_STAT_IF_IN_MULTICAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_OCTETS\":\"0\",\"SAI_PORT_STAT_IF_IN_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS\":\"0\",\"SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_OUT_DISCARDS\":\"0\",\"SAI_PORT_STAT_IF_OUT_ERRORS\":\"0\",\"SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_OUT_OCTETS\":\"0\",\"SAI_PORT_STAT_IF_OUT_QLEN\":\"0\",\"SAI_PORT_STAT_IF_OUT_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IP_IN_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_0_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_0_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_1_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_1_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_2_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_2_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_3_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_3_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_4_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_4_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_5_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_5_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_6_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_6_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_7_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_7_TX_PKTS\":\"0\"}"
    >
  >
>