### PR TITLE
Fix the version of github.com/openconfig/gnoi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,4 @@ require (
 )
 
 replace github.com/Azure/sonic-mgmt-common => ../sonic-mgmt-common
+replace github.com/openconfig/gnoi => github.com/openconfig/gnoi v0.0.0-20201210212451-209899112bb7


### PR DESCRIPTION
Fix https://github.com/Azure/sonic-buildimage/issues/7268

- Why I did it
The error message below is occurred in building image.
```
gnmi_server/server.go:144:42: cannot use srv (type *Server) as type system.SystemServer in argument to system.RegisterSystemServer:
  *Server does not implement system.SystemServer (missing system.mustEmbedUnimplementedSystemServer method)
```

- How I did it
Lock the version of github.com/openconfig/gnoi to previous version.