### PR TITLE
Add dataset "device syslog" to non-db client

### DIFF
--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -101,6 +101,10 @@ var (
 			path:    []string{"OTHERS", "osversion", "build"},
 			getFunc: dataGetFunc(getBuildVersion),
 		},
+		{ // Get device syslog
+			path:    []string{"OTHERS", "device", "syslog"},
+			getFunc: dataGetFunc(getDeviceSyslog),
+		},
 	}
 )
 
@@ -227,6 +231,33 @@ func getCpuUtil() ([]byte, error) {
 	}
 	log.V(4).Infof("getCpuUtil, output %v", string(b))
 	return b, nil
+}
+
+func getDeviceSyslog() ([]byte, error) {
+	hostName := "localhost"
+	portNum := "5150"
+	service := hostName + ":" + portNum
+	bufferSize := 1024
+	RemoteAddr, err := net.ResolveUDPAddr("udp4", service)
+	portConn, err := net.ListenUDP("udp4", RemoteAddr)
+	if err != nil {
+		log.V(2).Infof("%v", err)
+		return nil, err
+	}
+	defer portConn.Close()
+	buffer := make([]byte, bufferSize)
+	payloadSize, _, err := portConn.ReadFromUDP(buffer)
+	if err != nil {
+		log.V(2).Infof("%v", err)
+		return buffer, err
+	}
+	if bufferSize < payloadSize {
+		log.V(2).Infof("Payload was larger than buffer", err)
+		return nil, nil
+	}
+
+	log.V(4).Infof("getDeviceSyslog, output %v", string(buffer[:payloadSize]))
+	return buffer[:payloadSize], nil
 }
 
 func getProcMeminfo() ([]byte, error) {

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"sync"
 	"time"
 


### PR DESCRIPTION
This PR aims to enable the streaming telemetry container to stream out the system logs from the SONiC Host. This dataset is added into non-database client since syslog messages are generated quite frequently.

Implementation:
This data set listens to the syslog server UDP port and extracts the messages from the payload of the UDP packets sent across.

How To Test:
We can use the command ./gnmi_cli -client_types=gnmi -a <DuT_IP>:8080 -t OTHERS -logtostderr -insecure -qt p -pi 10s -q device/syslog to query for syslog messages every 10 seconds.

Unit Tests will be added in a future iteration. 