### PR TITLE
Validate Addrs in the format IP:Port

### DIFF
--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -89,7 +89,10 @@ func (d Destination) Validate() error {
 	if len(d.Addrs) == 0 {
 		return errors.New("Destination.Addrs is empty")
 	}
-	// TODO: validate Addrs is in format IP:PORT
+
+	if !strings.Contains(d.Addrs, ":") && len(strings.Split(d.Addrs, ":")) != 2 {
+		return errors.New("Destination.Addrs IP validation failed")
+	}
 	return nil
 }
 


### PR DESCRIPTION
If a random string is passed, it can be validated which is **incorrect**.

The appended commit validates the Addrs in the format IP:port and ensures there are two values.