### PR TITLE
[Tentative for memleak][No merge]: Force OS mem release

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net"
 	"sync"
+	"runtime"
+	"runtime/debug"
 
 	"github.com/Workiva/go-datastructures/queue"
 	log "github.com/golang/glog"
@@ -83,6 +85,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 		if err != nil {
 			c.errors++
 		}
+        log.V(2).Infof("Client %s exiting", c)
 	}()
 
 	query, err := stream.Recv()
@@ -261,5 +264,8 @@ func (c *Client) send(stream gnmipb.GNMI_SubscribeServer) error {
 			return err
 		}
 		log.V(5).Infof("Client %s done sending, msg count %d, msg %v", c, c.sendMsg, resp)
+		debug.FreeOSMemory()
+		n := runtime.NumGoroutine()
+		log.V(1).Infof("Force mem release; numRoutine=%v", n)
 	}
 }

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"runtime"
+	"runtime/debug"
 
 	log "github.com/golang/glog"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/go-redis/redis"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
+
 
 const (
 	// indentString represents the default indentation string used for
@@ -219,6 +222,9 @@ func (c *DbClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *sync
 
 	<-c.channel
 	log.V(1).Infof("Exiting StreamRun routine for Client %v", c)
+	debug.FreeOSMemory()
+	n := runtime.NumGoroutine()
+	log.V(1).Infof("Force mem release; numRoutine=%v", n)
 }
 
 // streamOnChangeSubscription implements Subscription "ON_CHANGE STREAM" mode
@@ -300,6 +306,9 @@ func (c *DbClient) PollRun(q *queue.PriorityQueue, poll chan struct{}, w *sync.W
 			},
 		})
 		log.V(4).Infof("Sync done, poll time taken: %v ms", int64(time.Since(t1)/time.Millisecond))
+		debug.FreeOSMemory()
+		n := runtime.NumGoroutine()
+		log.V(1).Infof("Force mem release; numRoutine=%v", n)
 	}
 }
 func (c *DbClient) OnceRun(q *queue.PriorityQueue, once chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
@@ -797,6 +806,9 @@ func dbFieldMultiSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, in
 			log.V(1).Infof("Queue error:  %v", err)
 			return err
 		}
+		debug.FreeOSMemory()
+		n := runtime.NumGoroutine()
+		log.V(1).Infof("Force mem release; numRoutine=%v", n)
 
 		return nil
 	}
@@ -874,6 +886,9 @@ func dbFieldSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, interva
 			log.V(1).Infof("Queue error:  %v", err)
 			return err
 		}
+		debug.FreeOSMemory()
+		n := runtime.NumGoroutine()
+		log.V(1).Infof("Force mem release; numRoutine=%v", n)
 
 		return nil
 	}
@@ -1043,6 +1058,9 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 		if err = c.q.Put(Value{spbv}); err != nil {
 			return fmt.Errorf("Queue error:  %v", err)
 		}
+		debug.FreeOSMemory()
+		n := runtime.NumGoroutine()
+		log.V(1).Infof("Force mem release; numRoutine=%v", n)
 
 		return nil
 	}
@@ -1126,7 +1144,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 
 		select {
 		case updatedTable := <-updateChannel:
-			log.V(1).Infof("update received: %v", updatedTable)
+			// log.V(1).Infof("update received: %v", updatedTable)
 			if interval == 0 {
 				// on-change mode, send the updated data.
 				if err := sendMsiData(updatedTable); err != nil {
@@ -1140,7 +1158,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 				}
 			}
 		case <-intervalTicker:
-			log.V(1).Infof("ticker received: %v", len(msiAll))
+			// log.V(1).Infof("ticker received: %v", len(msiAll))
 
 			if err := sendMsiData(msiAll); err != nil {
 				handleFatalMsg(err.Error())
@@ -1150,7 +1168,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 			// Clear the payload so that next time it will send only updates
 			if updateOnly {
 				msiAll = make(map[string]interface{})
-				log.V(1).Infof("msiAll cleared: %v", len(msiAll))
+				// log.V(1).Infof("msiAll cleared: %v", len(msiAll))
 			}
 
 		case <-c.channel:

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"io/ioutil"
 	"time"
+	"runtime"
+	"runtime/debug"
 
 	log "github.com/golang/glog"
 	"google.golang.org/grpc"
@@ -130,6 +132,15 @@ func main() {
 
 	gnmi.GenerateJwtSecretKey()
 }
+
+    go func() {
+        for {
+			debug.FreeOSMemory()
+			n := runtime.NumGoroutine()
+			log.V(1).Infof("Force mem release; numRoutine=%v", n)
+			time.Sleep(5 * time.Second)
+		}
+	}()
 
 	s, err := gnmi.NewServer(cfg, opts)
 	if err != nil {


### PR DESCRIPTION
First cut; Fixed leak in my repro;
[ Done on commit that is in 202012 -- 1c3f75e0d2b635dcff7d1bdff5cc9a03ed4bf7c5 ]

./gnmi_cli --client_types=gnmi -alocalhost:50051 -q COUNTERS -logtostderr -insecure -timestamp on -t COUNTERS_DB -qt s -streaming_type ON_CHANGE

**TODO:** Try it with repro from Pradnya.

**Changes:**
1) Force free mem in heap release back to OS
2) Fix possible subroutine leak
3) Cut down a log at level 1, which can be too much
4) Print count of GO routines for monitoring purpose

**Some Analysis:**
a) **No leak of subscribe clients**
    Matched count of initial poll queries with client shutdown message
```
grep -i -e "mode:[ ]*poll" x | tr -s " " | cut -f13 -d' ' | sort | uniq > poll.addr
  ½
admin@str-s6000-acs-14:~/data$ grep -i -e "mode:[ ]*poll" x | tr -s " " | cut -f13 -d' ' | wc -l
2959
admin@str-s6000-acs-14:~/data$ grep -i -e "mode:[ ]*poll" x | tr -s " " | cut -f13 -d' ' | sort | uniq | wc -l
2959
admin@str-s6000-acs-14:~/data$ grep -e "client_subscribe.go.*shutdown" x | tr -s " " | cut -f13 -d' ' |sort | uniq | wc -l
2955

```
b) **No leak of Go routines:**
Looked at the count from logs. It increased during my repro run and went back to original + 1 after I stopped the client. 
Not sure about that +1

```
Feb 12 13:26:18.012516 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 13:26:18.011588      20 telemetry.go:140] Force mem release; numRoutine=18
Feb 12 13:26:19.713555 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 13:26:19.710227      20 db_client.go:1063] Force mem release; numRoutine=25
Feb 12 13:26:19.831333 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 13:26:19.823717      20 client_subscribe.go:268] Force mem release; numRoutine=26
Feb 12 13:26:19.933282 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 13:26:19.928824      20 db_client.go:1063] Force mem release; numRoutine=26
Feb 12 13:26:20.007562 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 13:26:20.005470      20 client_subscribe.go:268] Force mem release; numRoutine=26
Feb 12 13:26:20.069412 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 13:26:20.065920      20 client_subscribe.go:268] Force mem release; numRoutine=26
...
Feb 12 14:01:02.706342 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 14:01:02.704680      20 db_client.go:1063] Force mem release; numRoutine=26
Feb 12 14:01:02.767171 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 14:01:02.763155      20 db_client.go:1063] Force mem release; numRoutine=26
Feb 12 14:01:02.818160 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 14:01:02.815669      20 client_subscribe.go:268] Force mem release; numRoutine=23
Feb 12 14:01:02.869548 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 14:01:02.866421      20 db_client.go:1063] Force mem release; numRoutine=23
Feb 12 14:01:02.870280 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 14:01:02.866490      20 db_client.go:227] Force mem release; numRoutine=23
Feb 12 14:01:04.796773 str-s6000-acs-12 INFO telemetry#/supervisord: telemetry I0212 14:01:04.795646      20 telemetry.go:140] Force mem release; numRoutine=19

```

c) **Invalid connections go away quick**

The subscribe RPC call create a gnmi_client/client_subscribe and call Run on it
New gnmi-client from client_subscribe wait for subscribe request
Creates DB client, if target is DB
DB client, does fetch on table keys and this fails
DB client terminates right there
gnmi-client exits  right away

```
Feb 12 00:19:38.480827 str-s6000-acs-14 INFO telemetry#/supervisord: telemetry I0212 00:19:38.478993      19 client_subscribe.go:97] Client 25.111.173.199:38610 recieved initial query subscribe:{prefix:{target:"STATE_DB"}  subscription:{path:{elem:{name:"DOCKER_STATS"}}  mode:SAMPLE  sample_interval:30}  subscription:{path:{elem:{name:"TEST_STATS"}}  mode:SAMPLE  sample_interval:30}  subscription:{path:{elem:{name:"TEST_STATS2"}}  mode:SAMPLE  sample_interval:30}  subscription:{path:{elem:{name:"TEST_STATS3"}}  mode:SAMPLE  sample_interval:30}  subscription:{path:{elem:{name:"TEST_STATS4"}}  mode:SAMPLE  sample_interval:30}  subscription:{path:{elem:{name:"TEST_STATS5"}}  mode:SAMPLE  sample_interval:30}  subscription:{path:{elem:{name:"TEST_STATS6"}}  mode:SAMPLE  sample_interval:30}  mode:POLL  encoding:JSON_IETF}
Feb 12 00:19:38.482243 str-s6000-acs-14 INFO telemetry#/supervisord: telemetry I0212 00:19:38.481365      19 db_client.go:506] Invalid db table Path STATE_DB TEST_STATS
Feb 12 00:19:38.482243 str-s6000-acs-14 INFO telemetry#/supervisord: telemetry I0212 00:19:38.481503      19 client_subscribe.go:134] Client 25.111.173.199:38610 shutdown

```







