### PR TITLE
[lgtm] tag cfg folder as generated, to prevent lgtm python detection

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,3 +1,7 @@
+path_classifiers:
+  generated:
+    - cfg
+
 extraction:
   go:
     before_index:


### PR DESCRIPTION
#### Why I did it
Prevent lgtm python detection

#### How I did it
Tag cfg folder as generated

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

